### PR TITLE
Fix wrong timestamp field

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_generator_plugin` to your list 
 ```elixir
 def deps do
   [
-    {:membrane_generator_plugin, "~> 0.2.0"}
+    {:membrane_generator_plugin, "~> 0.2.2"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_generator_plugin` to your list 
 ```elixir
 def deps do
   [
-    {:membrane_generator_plugin, "~> 0.2.1"}
+    {:membrane_generator_plugin, "~> 0.2.0"}
   ]
 end
 ```

--- a/lib/blank_video_generator.ex
+++ b/lib/blank_video_generator.ex
@@ -84,7 +84,7 @@ defmodule Membrane.BlankVideoGenerator do
     {ts, new_state} = get_timestamp(state)
 
     if ts < duration do
-      buffer = %Buffer{payload: frame, metadata: %{pts: ts}}
+      buffer = %Buffer{payload: frame, pts: ts}
       get_buffers(size - 1, new_state, [buffer | acc])
     else
       {:eos, Enum.reverse(acc), state}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Template.Mixfile do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.0"
   @github_url "https://github.com/membraneframework/membrane_generator_plugin"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Template.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.2"
   @github_url "https://github.com/membraneframework/membrane_generator_plugin"
 
   def project do

--- a/test/membrane/blank_video_generator_test.exs
+++ b/test/membrane/blank_video_generator_test.exs
@@ -59,9 +59,9 @@ defmodule Membrane.BlankVideoGeneratorTest do
     assert_start_of_stream(pid, :sink)
     assert_sink_caps(pid, :sink, caps)
 
-    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_1, metadata: %{pts: pts_1}})
-    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_2, metadata: %{pts: pts_2}})
-    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_3, metadata: %{pts: pts_3}})
+    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_1, pts: pts_1})
+    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_2, pts: pts_2})
+    assert_sink_buffer(pid, :sink, %Buffer{payload: payload_3, pts: pts_3})
 
     assert pts_1 == 0
     assert pts_2 == Membrane.Time.seconds(1)


### PR DESCRIPTION
Since `0.8.0` version of `membrane_core` the `pts` should be stored directly in the Buffer, not as field of metadata field.